### PR TITLE
fix(azureBlob): fix error description for azure blob upload format field

### DIFF
--- a/packages/i18n/lib/en/integrationDesc.ts
+++ b/packages/i18n/lib/en/integrationDesc.ts
@@ -545,7 +545,7 @@ export const enIntegrationDesc: Record<string, Record<string, string>> = {
     time_interval: 'Amount of time events will be aggregated in a single object before uploading.',
     content: 'The content of the object to be uploaded supports placeholders.',
     blob: 'Azure Blob Storage blob name.',
-    container: 'Azure Blob Storage container name.',
+    parameters_container: 'Azure Blob Storage container name.',
   },
   snowflake: {
     private_key:

--- a/packages/i18n/lib/zh/integrationDesc.ts
+++ b/packages/i18n/lib/zh/integrationDesc.ts
@@ -492,7 +492,7 @@ export const zhIntegrationDesc: Record<string, Record<string, string>> = {
     content:
       "要存储的对象的内容。默认情况下，它是包含所有字段的 JSON 文本格式。支持如 ${'{'}payload{'}'} 的占位符设置。存储格式取决于变量的格式，支持二进制内容。",
     blob: 'Azure Blob Storage blob 名称。',
-    container: 'Azure Blob Storage 容器名称。',
+    parameters_container: 'Azure Blob Storage 容器名称。',
   },
   snowflake: {
     private_key:


### PR DESCRIPTION
Fix incorrect description for Azure Blob upload format field by using path-based definition due to duplicate 'container' keys
<img width="585" height="177" alt="image" src="https://github.com/user-attachments/assets/73af10d7-1bad-44e2-ae6e-d0e28fba2f25" />
<img width="729" height="594" alt="image" src="https://github.com/user-attachments/assets/20098a62-272d-4cd6-9fcf-494dde6f5e68" />
